### PR TITLE
Add Nix flake for reproducible builds and formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# See editorconfig.org for full list of options.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[.envrc]
+indent_style = tab
+
+[*.rs]
+indent_style = space
+indent_style = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# shellcheck shell=sh
+if command -v nix >/dev/null 2>/dev/null; then
+	use flake
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,15 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nix fmt -- --ci
+
   test:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       RUSTFLAGS: "-D warnings"
 
     steps:
-    - uses: actions/checkout@master
-    - name: minimum feature
-      run: |
-        cargo test --no-default-features
+      - uses: actions/checkout@master
+      - name: minimum feature
+        run: |
+          cargo test --no-default-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+/.pre-commit-config.yaml
+/result
 /target

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.direnv/
 /.pre-commit-config.yaml
 /result
 /target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "unzrip"
+description = "Unzip implementation with parallel decompression and automatic detection encoding"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace]
-members = [ "zip-parser" ]
+members = ["zip-parser"]
 
 [features]
-default = [ "zstd-sys" ]
-zstd-sys = [ "zstd" ]
+default = ["zstd-sys"]
+zstd-sys = ["zstd"]
 
 [dependencies]
 zip-parser = { path = "zip-parser" }
@@ -31,7 +31,7 @@ crc32fast = "1"
 
 # compress
 flate2 = "1"
-zstd = { version = "0.12", features = [ "pkg-config" ], optional = true }
+zstd = { version = "0.12", features = ["pkg-config"], optional = true }
 
 # encoding
 encoding_rs = "0.8"
@@ -42,7 +42,7 @@ time = "0.3"
 filetime = "0.2"
 
 [dev-dependencies]
-zip = { version = "0.6", default-features = false, features = [ "deflate" ] }
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
 tempfile = "3"
 assert_cmd = "2"
 walkdir = "2"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you have ever downloaded a zip file with
 an encoded filename using a character set such as GBK or SHIFT-JIS,
 then you know what that means.
 
-##  Parallel decompression
+## Parallel decompression
 
 All files in zip can be decompressed independently,
 which means that more files there are,

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,262 @@
+{
+  "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1756811102,
+        "narHash": "sha256-cFWBvfH6WyptwjpeTd3iun5ZV62adGNWz95b6Ec979U=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "20a8af2bdc91ffaa99fed197adf0e40c0e8c5edd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1750266157,
+        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755960406,
+        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nix-systems": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758073512,
+        "narHash": "sha256-+3US/eD3Enje7mwwbebYpSSoLl11cfaQoU7wfPuEvJA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e509527e1de499fdcabbf2e5d700c666f3ef7521",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "flake-parts": "flake-parts",
+        "git-hooks-nix": "git-hooks-nix",
+        "nix-systems": "nix-systems",
+        "nixpkgs": "nixpkgs",
+        "rust-flake": "rust-flake",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-flake": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1754334528,
+        "narHash": "sha256-YNVR1GtmcVsXQmAFwvY5zUSq6Suoo/i0xLCdXYLnzOA=",
+        "owner": "juspay",
+        "repo": "rust-flake",
+        "rev": "050986c99c6a84567f18a49395bac3aebb635bde",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "rust-flake",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "rust-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1751510438,
+        "narHash": "sha256-m8PjOoyyCR4nhqtHEBP1tB/jF+gJYYguSZmUmVTEAQE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7f415261f298656f8164bd636c0dc05af4e95b6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1756662192,
+        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,96 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    git-hooks-nix = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nix-systems = {
+      url = "github:nix-systems/default";
+      flake = false;
+    };
+    rust-flake.url = "github:juspay/rust-flake";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+  };
+
+  outputs =
+    inputs@{ flake-parts, nix-systems, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      top@{
+        config,
+        withSystem,
+        moduleWithSystem,
+        ...
+      }:
+      {
+        imports = [
+          inputs.git-hooks-nix.flakeModule
+          inputs.rust-flake.flakeModules.default
+          inputs.rust-flake.flakeModules.nixpkgs
+          inputs.treefmt-nix.flakeModule
+        ];
+        systems = (import nix-systems);
+        perSystem =
+          {
+            config,
+            self',
+            pkgs,
+            ...
+          }:
+          {
+            devShells.default = config.rust-project.crane-lib.devShell {
+              inputsFrom = [
+                config.packages.unzrip
+                config.pre-commit.devShell
+                config.treefmt.build.devShell
+              ];
+            };
+            packages = {
+              default = self'.packages.unzrip;
+            };
+            pre-commit = {
+              check.enable = true;
+              settings.hooks = {
+                editorconfig-checker.enable = true;
+                ripsecrets.enable = true;
+                taplo.enable = true;
+                treefmt.enable = true;
+                typos.enable = true;
+              };
+            };
+            rust-project = {
+              crates.unzrip = {
+                crane.args = {
+                  buildInputs = with pkgs; [
+                    zstd
+                  ];
+                  nativeBuildInputs = with pkgs; [
+                    pkg-config
+                  ];
+                };
+                path = ./.;
+              };
+            };
+            treefmt.config = {
+              projectRootFile = ".git/config";
+              flakeCheck = false; # use pre-commit's check instead
+              programs = {
+                nixfmt.enable = true; # nix
+                prettier.enable = true;
+                shellcheck.enable = true;
+                shfmt = {
+                  enable = true;
+                  indent_size = 0;
+                };
+                taplo.enable = true;
+              };
+            };
+          };
+      }
+    );
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
This builds on #9 by defining a Nix flake for reproducible builds. Formatters declared in the flake are also used to autoformat the repository.